### PR TITLE
Enable Azure RBAC for Key Vault Deployment

### DIFF
--- a/deployment/main.bicep
+++ b/deployment/main.bicep
@@ -9,8 +9,8 @@ param resourceGroupName string
 @description('Specifies the name of the key vault.')
 param keyVaultName string
 
-@description('Specifies the object ID of the user or service principal.')
-param objectId string
+@description('Role assignments for the vault')
+param roleAssignments array
 
 // Create Resource Group
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -25,7 +25,7 @@ module keyVault 'keyvault.bicep' = {
   params: {
     keyVaultName: keyVaultName
     location: location
-    objectId: objectId
+    roleAssignments: roleAssignments
   }
 }
 

--- a/deployment/parameters.json
+++ b/deployment/parameters.json
@@ -1,18 +1,18 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "value": "eastus"
-        },
-        "resourceGroupName": {
-            "value": "rg-myapp"
-        },
-        "keyVaultName": {
-            "value": "kv-myapp"
-        },
-        "objectId": {
-            "value": ""
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    },
+    "resourceGroupName": {
+      "value": "rg-myapp"
+    },
+    "keyVaultName": {
+      "value": "kv-myapp"
+    },
+    "roleAssignments": {
+      "value": []
     }
+  }
 }


### PR DESCRIPTION
Refactored Key Vault deployment Bicep templates to use Azure RBAC instead of legacy access policies, including template version update, new roleAssignments parameter, and related parameter file adjustments.