### PR TITLE
Upgrade cross-spawn to 7.0.5 to fix CVE-2024-21538

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,6 +1923,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2138,21 +2153,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "vite": "^6.3.5"
   },
   "overrides": {
-    "cross-spawn": "7.0.3"
+    "cross-spawn": "7.0.5"
   }
 }


### PR DESCRIPTION
Updated package.json override for cross-spawn from 7.0.3 to 7.0.5, ran npm install to regenerate package-lock.json, and verified that cross-spawn@7.0.5 is installed. This patch addresses the ReDoS vulnerability CVE-2024-21538.