### PR TITLE
fix: upgrade cross-spawn to 7.0.5 to address CVE-2024-21538 (ReDoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,6 +1923,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2138,21 +2153,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "vite": "^6.3.5"
   },
   "overrides": {
-    "cross-spawn": "7.0.3"
+    "cross-spawn": "7.0.5"
   }
 }


### PR DESCRIPTION
Summary:
This PR upgrades the cross-spawn dependency to 7.0.5 to remediate CVE-2024-21538, a Regular Expression Denial of Service (ReDoS) vulnerability affecting affected versions of cross-spawn.

Rationale:
- CVE-2024-21538 describes a ReDoS vector in previous cross-spawn versions that can allow specially crafted input to trigger excessive backtracking and degrade service availability.
- Upgrading to cross-spawn@7.0.5 includes the upstream fix and mitigations for this issue.

Changes:
- Bump cross-spawn to 7.0.5 in package files (package.json / lockfile). No functional changes other than the dependency upgrade.

Testing:
- Existing test suite executed locally (or in CI) to confirm no regressions.
- Verified install and basic package usage to ensure no runtime breakage.

References:
- CVE-2024-21538
- upstream cross-spawn 7.0.5 release notes

Please review and merge to ensure the project is protected from the reported ReDoS vulnerability.