### PR TITLE
Remediate cross-spawn CVE: force cross-spawn@7.0.6 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,6 +1923,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2138,21 +2153,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "vite": "^6.3.5"
   },
   "overrides": {
-    "cross-spawn": "7.0.3"
+    "cross-spawn": "7.0.6"
   }
 }


### PR DESCRIPTION
Summary

This PR remediates the known cross-spawn CVE by forcing the patched cross-spawn@7.0.6 across the dependency tree using package.json overrides.

What I changed

- package.json: updated overrides to force cross-spawn => 7.0.6
- package-lock.json: updated by running npm install to lock cross-spawn@7.0.6

Commit

- 24a830e55e7f24ef4a31f6c8dafad57efb88160e

Actions taken / verification

- Updated package.json overrides: cross-spawn 7.0.3 -> 7.0.6
- Ran npm install: package-lock.json updated to resolve cross-spawn@7.0.6
  - npm install reported 4 vulnerabilities (2 low, 2 moderate) unrelated to cross-spawn and suggested `npm audit fix`.
- Ran npm run lint: passed
- Ran npm test: no test script present
- Verified git status is clean and branch is agent/fix/task-1765739069779

Files changed

- package.json
- package-lock.json

Goal

Force the patched cross-spawn version (7.0.6) across the dependency tree to remediate the CVE. The remaining reported vulnerabilities are unrelated to cross-spawn and can be handled in a follow-up if desired.

Please review and merge into the repository default branch.