### PR TITLE
remediation(iac): Harden Key Vault - disable public access, add firewall and recovery settings

### DIFF
--- a/deployment/keyvault.bicep
+++ b/deployment/keyvault.bicep
@@ -51,6 +51,28 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enabledForDiskEncryption: enabledForDiskEncryption
     enabledForTemplateDeployment: enabledForTemplateDeployment
     tenantId: tenantId
+
+    // MDC: d9be0ff8-3eb0-4348-82f6-c1e735f85983 - CKV_AZURE_189: Disable public network access
+    // Disables public access to the vault; allow access via network rules only
+    publicNetworkAccess: 'Disabled'
+
+    // MDC: d9be0ff8-3eb0-4348-82f6-c1e735f85983 - AZR-000355 / CKV_AZURE_109: network ACLs and firewall rules
+    // Default deny to enforce allow-listing of IPs/VNETs. ipRules and virtualNetworkRules are empty by default; update as required.
+    networkAcls: {
+      defaultAction: 'Deny'
+      // Keep AzureServices bypass if needed for platform services; adjust if stricter posture required
+      bypass: 'AzureServices'
+      ipRules: []
+      virtualNetworkRules: []
+    }
+
+    // MDC: d9be0ff8-3eb0-4348-82f6-c1e735f85983 - CKV_AZURE_42: Enable soft-delete to retain deleted vault objects
+    enableSoftDelete: true
+
+    // MDC: d9be0ff8-3eb0-4348-82f6-c1e735f85983 - CKV_AZURE_110: Enable purge protection
+    // NOTE: Purge protection is irreversible once enabled. Require stakeholder approval before enabling in production.
+    enablePurgeProtection: true
+
     accessPolicies: [
       {
         objectId: objectId
@@ -67,6 +89,8 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     }
   }
 }
+
+// Note: AZR-000388 (RBAC migration) is out of scope for this IaC change; RBAC migration should be planned and executed separately.
 
 output keyVaultName string = keyVault.name
 output keyVaultId string = keyVault.id


### PR DESCRIPTION
This PR implements Key Vault hardening changes to address findings from the MDC assessment.

MDC assessment ID: d9be0ff8-3eb0-4348-82f6-c1e735f85983
Findings addressed (IDs/rules): CKV_AZURE_189, AZR-000355, CKV_AZURE_109, CKV_AZURE_42, CKV_AZURE_110

Summary of changes:
- deployment/keyvault.bicep: Disable public network access, add networkAcls with defaultAction='Deny', enable soft-delete and purge protection (with inline note requiring stakeholder approval), add comments referencing MDC findings and note that AZR-000388 (RBAC migration) is out of scope.

Files changed (one-line summaries):
- deployment/keyvault.bicep — added publicNetworkAccess: 'Disabled', networkAcls defaultAction: 'Deny', enableSoftDelete: true, enablePurgeProtection: true; added MDC finding comments and purge-protection approval note.

Before/after IaC scan outputs (local):
- checkov: failed to run locally: "checkov: command not found"
- templateanalyzer: failed to run locally: "zsh:1: command not found: templateanalyzer"

Note: Scans could not be run locally because the tools are not installed in the execution environment. CI should run the following commands to validate scans:
- checkov -f deployment/keyvault.bicep
- templateanalyzer -f deployment/keyvault.bicep

Git commit & push summary:
- Commit: 04ba8f8eb8136dc4b9be47200d923e6eb628074a
- Branch pushed: agent/fix/task-1765877053845 (unable to create requested branch remediation/iac/keyvault-hardening due to local command limitations; changes are on the pushed branch above)
- Commit message: "remediation(iac): Harden Key Vault - disable public access, add firewall and recovery settings"
- Changes: 1 file modified (deployment/keyvault.bicep), ~24 insertions, 0 deletions

Notes and requests:
- CKV_AZURE_110 (enable purge protection) is irreversible — this PR enables it and includes an inline note; please confirm stakeholder approval before merging to production.
- AZR-000388 (RBAC migration) is out of scope for this change and requires a separate migration plan.

Requested reviewers:
- Dolev Cohen
- Repository owners

If you prefer the branch be named exactly remediation/iac/keyvault-hardening, I can re-run the branch creation and push steps locally or you can rename the branch on remote; current pushed branch is agent/fix/task-1765877053845.
