### PR TITLE
Remediate Key Vault security — Assessment d9be0ff8-3eb0-4348-82f6-c1e735f85983 (CKV_AZURE_189, AZR-000355, CKV_AZURE_42, CKV_AZURE_109, CKV_AZURE_110, AZR-000388)

### DIFF
--- a/deployment/keyvault.bicep
+++ b/deployment/keyvault.bicep
@@ -51,16 +51,15 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enabledForDiskEncryption: enabledForDiskEncryption
     enabledForTemplateDeployment: enabledForTemplateDeployment
     tenantId: tenantId
-    accessPolicies: [
-      {
-        objectId: objectId
-        tenantId: tenantId
-        permissions: {
-          keys: keysPermissions
-          secrets: secretsPermissions
-        }
-      }
-    ]
+    // Security hardening
+    enableSoftDelete: true
+    enablePurgeProtection: true
+    enableRbacAuthorization: true
+    publicNetworkAccess: 'Disabled'
+
+    // Remove legacy access policies in favor of Azure RBAC
+    accessPolicies: []
+
     sku: {
       name: skuName
       family: 'A'


### PR DESCRIPTION
Assessment ID: d9be0ff8-3eb0-4348-82f6-c1e735f85983

Affected findings and fixes applied:
- CKV_AZURE_189 (publicNetworkAccess): Set properties.publicNetworkAccess = 'Disabled' to prevent public network access.
- AZR-000355 / CKV_AZURE_109 (firewall/network ACLs): Default-deny posture applied by disabling publicNetworkAccess; ipRules/virtualNetworkRules left empty (deny by default). Add rules if legitimate access required.
- CKV_AZURE_42 (soft delete/recoverable): Enabled enableSoftDelete = true.
- CKV_AZURE_110 (purge protection): Enabled enablePurgeProtection = true.
- AZR-000388 (use RBAC): Removed legacy accessPolicies and enabled enableRbacAuthorization = true to use Azure RBAC.

Files changed (minimal):
- deployment/keyvault.bicep
  - enableSoftDelete: true — ensures deleted vault items are recoverable (CKV_AZURE_42).
  - enablePurgeProtection: true — prevents immediate purge of deleted vault items (CKV_AZURE_110).
  - enableRbacAuthorization: true — switches to Azure RBAC and removes legacy access policies (AZR-000388).
  - publicNetworkAccess: 'Disabled' — disables public network access (CKV_AZURE_189, AZR-000355, CKV_AZURE_109).
  - accessPolicies: [] — removed inline access policies to enforce RBAC.

Commit and branch:
- Branch: agent/fix/task-1765887163825
- Commit SHA: Unable to retrieve short SHA from environment (git rev-parse not available). Changes were committed and pushed to the branch.

Scanner run:
- Attempted to run Checkov locally: command not found (checkov not installed in this environment). Please run local IaC scanner (checkov) in your CI or locally to validate. CI can be updated to include checkov if desired.

Notes and manual follow-ups:
- If any legitimate public access is required, configure properties.networkAcls.ipRules and/or virtualNetworkRules with the allowed IP ranges or VNet IDs. I left them empty to enforce deny-by-default.
- After merging, validate RBAC assignments that grant required permissions to principals that previously relied on accessPolicies.
- Add checkov to CI (e.g., a workflow) if you want automated IaC scanning; I did not modify CI in this change.

References: Assessment d9be0ff8-3eb0-4348-82f6-c1e735f85983; findings: CKV_AZURE_189, AZR-000355, CKV_AZURE_42, CKV_AZURE_109, CKV_AZURE_110, AZR-000388.
