### PR TITLE
fix(iac): Key Vault network & data protection hardening (disable public access, network ACLs, soft-delete, purge-protection)

### DIFF
--- a/deployment/keyvault.bicep
+++ b/deployment/keyvault.bicep
@@ -43,14 +43,39 @@ param secretsPermissions array = [
 ])
 param skuName string = 'standard'
 
+// NOTE: This deployment performs minimal security hardening to address IaC scan findings.
+// - Disables public network access
+// - Adds network ACLs with defaultAction 'Deny' (bypass AzureServices)
+// - Enables soft-delete and purge-protection
+// TODO: Migrate accessPolicies to Azure RBAC in a follow-up change. Do NOT remove accessPolicies in this PR.
+
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
   location: location
   properties: {
+    // Network access: disable public network access and deny by default
+    publicNetworkAccess: 'Disabled'
+    networkAcls: {
+      defaultAction: 'Deny'
+      bypass: 'AzureServices'
+      // ipRules and virtualNetworkRules can be populated with management IPs or VNet/subnet resourceIds as needed.
+      ipRules: []
+      virtualNetworkRules: []
+      // Example placeholders (commented):
+      // ipRules: [ { value: '203.0.113.5' } ]
+      // virtualNetworkRules: [ { id: '/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<subnet>' } ]
+    }
+
+    // Data protection
+    enableSoftDelete: true
+    enablePurgeProtection: true
+
     enabledForDeployment: enabledForDeployment
     enabledForDiskEncryption: enabledForDiskEncryption
     enabledForTemplateDeployment: enabledForTemplateDeployment
     tenantId: tenantId
+
+    // Keep existing accessPolicies for backward compatibility. Migration to RBAC is TODO.
     accessPolicies: [
       {
         objectId: objectId
@@ -61,6 +86,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
         }
       }
     ]
+
     sku: {
       name: skuName
       family: 'A'


### PR DESCRIPTION
Summary

This PR addresses findings from the MDC assessment (ID: d9be0ff8-3eb0-4348-82f6-c1e735f85983) that recommended hardening Azure Key Vault configuration in IaC.

Findings remediated (minimal safe changes in this PR):
- Ensure Azure Key Vault disables public network access (High) — set publicNetworkAccess = 'Disabled'
- Configure Azure Key Vault firewall (High) — add properties.networkAcls with defaultAction = 'Deny', bypass = 'AzureServices', ipRules = [], virtualNetworkRules = [] (commented placeholders included for management IPs/VNet rules)
- Enable soft-delete (Medium) — set enableSoftDelete = true
- Enable purge-protection (Medium) — set enablePurgeProtection = true (enabled together with soft-delete)
- Allow firewall rules settings (Medium) — ipRules/virtualNetworkRules present as empty arrays with placeholders for future additions

Notes and out-of-scope items

- Migrate accessPolicies to Azure RBAC (Medium): Full migration is out-of-scope for this minimal remediation. accessPolicies are LEFT IN PLACE to avoid breaking existing access. A TODO comment was added in the template noting a follow-up PR is required to migrate to Azure RBAC and remove accessPolicies safely.

Files changed

- deployment/keyvault.bicep
  - Rationale: Add network and data protection properties to harden Key Vault per MDC findings. Kept accessPolicies intact to avoid access disruption; added TODO comment for RBAC migration.

Commits and branch

- Branch: agent/fix/task-1765887815598
- Commit: dda332f2f10bb5be8dde6745886c798be53bb817

Testing performed (basic checks)

- Verified file exists and was read before modification
- Applied minimal, syntactically-safe edits to deployment/keyvault.bicep
- Verified git diff showing additions for publicNetworkAccess, networkAcls, enableSoftDelete, enablePurgeProtection, and TODO comment
- Committed and pushed changes to branch above

Follow-up / next steps

- Validate deployment in a non-production environment
- Create follow-up PR to migrate accessPolicies to Azure RBAC and remove accessPolicies after testing
- Optionally add specific ipRules or virtualNetworkRules (management IPs or VNet/subnet resource IDs) as appropriate for your environment

If PR creation fails due to permission issues, I will report the failure with details so it can be remedied.