### PR TITLE
Fix MDC findings in deployment/keyvault.bicep: disable public network access, configure firewall, enable recoverability, purge protection, and RBAC

### DIFF
--- a/deployment/keyvault.bicep
+++ b/deployment/keyvault.bicep
@@ -47,6 +47,15 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
   location: location
   properties: {
+    enableSoftDelete: true,
+    enablePurgeProtection: true,
+    enableRbacAuthorization: true,
+    publicNetworkAccess: 'Disabled',
+    networkAcls: {
+      bypass: 'AzureServices',
+      defaultAction: 'Deny',
+      ipRules: []
+    },
     enabledForDeployment: enabledForDeployment
     enabledForDiskEncryption: enabledForDiskEncryption
     enabledForTemplateDeployment: enabledForTemplateDeployment


### PR DESCRIPTION
This PR addresses 6 MDC findings in deployment/keyvault.bicep:

High priority fixes:
- Disable public network access (CKV_AZURE_189)
- Configure firewall (AZR-000355)

Medium priority fixes:
- Ensure recoverability (CKV_AZURE_42)
- Enable firewall rules (CKV_AZURE_109)
- Enable purge protection (CKV_AZURE_110)
- Implement role-based access control (AZR-000388)

Changes include disabling public network access, configuring firewall rules to deny by default with AzureServices bypass, enabling soft delete and purge protection, and enabling RBAC authorization on the Key Vault resource.

Commit: 06773a6bc8a152cb19eab7073a85c8a602e98458
Branch: agent/fix/task-1765898163942

These changes improve security and compliance of the Key Vault deployment as per MDC recommendations.